### PR TITLE
Update finitude.py

### DIFF
--- a/finitude/finitude.py
+++ b/finitude/finitude.py
@@ -127,6 +127,8 @@ class HvacMonitor:
                             stype = 'discharge'
                         elif s['Type'] == 0x4a:
                             stype = 'superheat'
+                        elif s['Type'] == 0x4b:
+                            stype = 'discharge'
                         else:
                             stype = str(s['Type'])
                         temp = s['TempTimes16']
@@ -301,17 +303,15 @@ class HvacMonitor:
                     self.open()
                 frame = frames.ParsedFrame(self.bus.read())
                 (name, rest) = self.process_frame(frame)
-                if self.store_frames:
-                    HvacMonitor.FRAME_COUNT.labels(
+                HvacMonitor.FRAME_COUNT.labels(
                         name=self.name,
                         source=frames.ParsedFrame.get_printable_address(frame.source),
                         dest=frames.ParsedFrame.get_printable_address(frame.dest),
                         func=frame.get_function_name(),
                         register=name or frame.get_register() or 'unknown',
-                    ).inc()
+                ).inc()
+                if self.store_frames:
                     self.store_frame(frame, name, rest)
-                else:
-                    HvacMonitor.FRAME_COUNT.labels(name=self.name).inc()
                 if frame.func in (frames.Function.ACK06,
                                   frames.Function.ACK02,
                                   frames.Function.NACK):
@@ -383,7 +383,7 @@ def main(args, env=None):
     if listeners:
         config['listeners'] = listeners
     if config.get('debug_logging'):
-        logging.setLevel(logging.DEBUG)
+        LOGGER.setLevel(logging.DEBUG)
         LOGGER.debug('debug logging is on')
     f = Finitude(config)
     f.start_metrics_server()


### PR DESCRIPTION
Added dsicharge temperature at line 130 & 131

moved HvacMonitor.FRAME_COUNT.labels out of the if statement around line 313 to elminate an error every time I send the stop comment to the Snifserver:

After Stop command I was gettign these errors:

INFO:finitude:data collection stopped
192.168.1.150 - - [08/Jun/2024 17:08:19] "GET /stop HTTP/1.1" 200 23 Exception in thread lowerlevel:
Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/home/pi/PycharmProjects/finitude/finitude/finitude.py", line 322, in run
    HvacMonitor.FRAME_COUNT.labels(name=self.name).inc()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/PycharmProjects/finitude/venv/lib/python3.11/site-packages/prometheus_client/metrics.py", line 195, in labels
    raise ValueError('Incorrect label names')
ValueError: Incorrect label names
192.168.1.150 - - [08/Jun/2024 17:08:19] "GET /favicon.ico HTTP/1.1" 200 0


My line numbers are little different because I added many comments to my local file.